### PR TITLE
Fixes #64 Allow access to members through indirection

### DIFF
--- a/Sources/Core/Ast.swift
+++ b/Sources/Core/Ast.swift
@@ -377,6 +377,7 @@ class Selector: Node, Expr, Convertable {
 
     var checked: Checked!
     var type: Type!
+    var levelsOfIndirection: Int!
     var conversion: (from: Type, to: Type)?
     var constant: Value?
 
@@ -402,11 +403,12 @@ class Selector: Node, Expr, Convertable {
     var end: Pos { return sel.end }
 
 // sourcery:inline:auto:Selector.Init
-init(rec: Expr, sel: Ident, checked: Checked!, type: Type!, conversion: (from: Type, to: Type)?, constant: Value?) {
+init(rec: Expr, sel: Ident, checked: Checked!, type: Type!, levelsOfIndirection: Int!, conversion: (from: Type, to: Type)?, constant: Value?) {
     self.rec = rec
     self.sel = sel
     self.checked = checked
     self.type = type
+    self.levelsOfIndirection = levelsOfIndirection
     self.conversion = conversion
     self.constant = constant
 }

--- a/Sources/Core/IRGenerator.swift
+++ b/Sources/Core/IRGenerator.swift
@@ -1282,7 +1282,10 @@ extension IRGenerator {
             }
             return b.buildLoad(value(for: entity))
         case .struct(let field):
-            let aggregate = emit(expr: sel.rec, returnAddress: true)
+            var aggregate = emit(expr: sel.rec, returnAddress: true)
+            for _ in 0 ..< sel.levelsOfIndirection {
+                aggregate = b.buildLoad(aggregate)
+            }
             let fieldAddress = b.buildStructGEP(aggregate, index: field.index)
             if returnAddress {
                 return fieldAddress
@@ -1291,7 +1294,10 @@ extension IRGenerator {
         case .enum(let c):
             return canonicalize(sel.type as! ty.Enum).constant(c.number)
         case .union(let c):
-            let aggregate = emit(expr: sel.rec, returnAddress: true)
+            var aggregate = emit(expr: sel.rec, returnAddress: true)
+            for _ in 0 ..< sel.levelsOfIndirection {
+                aggregate = b.buildLoad(aggregate)
+            }
             let type = canonicalize(c.type)
             let address = b.buildBitCast(aggregate, type: LLVM.PointerType(pointee: type))
             if returnAddress {
@@ -1299,7 +1305,10 @@ extension IRGenerator {
             }
             return b.buildLoad(address)
         case .array(let member):
-            let aggregate = emit(expr: sel.rec, returnAddress: true)
+            var aggregate = emit(expr: sel.rec, returnAddress: true)
+            for _ in 0 ..< sel.levelsOfIndirection {
+                aggregate = b.buildLoad(aggregate)
+            }
             let index = member.rawValue
             let fieldAddress = b.buildStructGEP(aggregate, index: index)
             if returnAddress {

--- a/Sources/Core/Parser.swift
+++ b/Sources/Core/Parser.swift
@@ -219,7 +219,7 @@ extension Parser {
                 x = parseTernaryExpr(x)
             case .period:
                 next()
-                x = Selector(rec: x, sel: parseIdent(), checked: nil, type: nil, conversion: nil, constant: nil)
+                x = Selector(rec: x, sel: parseIdent(), checked: nil, type: nil, levelsOfIndirection: nil, conversion: nil, constant: nil)
             case .lbrack:
                 let lbrack = eatToken()
                 if tok == .colon {
@@ -347,7 +347,7 @@ extension Parser {
             let x = parseIdent()
             if tok == .period {
                 next()
-                return Selector(rec: x, sel: parseIdent(), checked: nil, type: nil, conversion: nil, constant: nil)
+                return Selector(rec: x, sel: parseIdent(), checked: nil, type: nil, levelsOfIndirection: nil, conversion: nil, constant: nil)
             }
             return x
         case .lbrack:

--- a/Sources/Core/generated/Copy.generated.swift
+++ b/Sources/Core/generated/Copy.generated.swift
@@ -621,6 +621,7 @@ func copy(_ node: Selector) -> Selector {
         sel: copy(node.sel),
         checked: node.checked,
         type: node.type,
+        levelsOfIndirection: node.levelsOfIndirection,
         conversion: node.conversion,
         constant: node.constant
     )


### PR DESCRIPTION
Could you implement the `case .scalar` and `case .swizzle` in ir gen. I assume they will pass through checking.