### PR TITLE
Refactored named types

### DIFF
--- a/Sources/Core/Ast.swift
+++ b/Sources/Core/Ast.swift
@@ -182,23 +182,24 @@ init(start: Pos, element: Expr?, type: Type!) {
 // sourcery:end
 }
 
-// this is constrained, not converted
-class BasicLit: Node, Expr {
+class BasicLit: Node, Expr, Convertable {
     var start: Pos
     var token: Token
     var text: String
     var type: Type!
     var constant: Value!
+    var conversion: (from: Type, to: Type)?
 
     var end: Pos { return start + text.count }
 
 // sourcery:inline:auto:BasicLit.Init
-init(start: Pos, token: Token, text: String, type: Type!, constant: Value!) {
+init(start: Pos, token: Token, text: String, type: Type!, constant: Value!, conversion: (from: Type, to: Type)?) {
     self.start = start
     self.token = token
     self.text = text
     self.type = type
     self.constant = constant
+    self.conversion = conversion
 }
 // sourcery:end
 }

--- a/Sources/Core/Builtins.swift
+++ b/Sources/Core/Builtins.swift
@@ -16,11 +16,10 @@ struct BuiltinType {
     }
 
     init(entity: Entity, type: NamableType) {
-        var type = type
         entity.flags.insert(.builtin)
         self.entity = entity
-        type.entity = entity
-        self.type = type
+        self.type = ty.Named(entity: entity, base: type)
+        entity.type = type
     }
     static let void = BuiltinType(entity: .void, type: ty.Void())
     static let any  = BuiltinType(entity: .any,  type: ty.Anyy())
@@ -29,17 +28,17 @@ struct BuiltinType {
     static let rawptr = BuiltinType(entity: .rawptr, type: ty.Pointer(pointeeType: ty.u8))
     static let string = BuiltinType(entity: .string, type: ty.KaiString())
 
-    static let f32 = BuiltinType(entity: .f32, type: ty.FloatingPoint(entity: .f32, width: 32))
-    static let f64 = BuiltinType(entity: .f64, type: ty.FloatingPoint(entity: .f64, width: 64))
+    static let f32 = BuiltinType(entity: .f32, type: ty.FloatingPoint(width: 32))
+    static let f64 = BuiltinType(entity: .f64, type: ty.FloatingPoint(width: 64))
 
-    static let i8  = BuiltinType(entity: .i8,  type: ty.Integer(entity: .i8 , width: 8,  isSigned: true))
-    static let u8  = BuiltinType(entity: .u8,  type: ty.Integer(entity: .u8 , width: 8,  isSigned: false))
-    static let i16 = BuiltinType(entity: .i16, type: ty.Integer(entity: .i16, width: 16, isSigned: true))
-    static let u16 = BuiltinType(entity: .u16, type: ty.Integer(entity: .u16, width: 16, isSigned: false))
-    static let i32 = BuiltinType(entity: .i32, type: ty.Integer(entity: .i32, width: 32, isSigned: true))
-    static let u32 = BuiltinType(entity: .u32, type: ty.Integer(entity: .u32, width: 32, isSigned: false))
-    static let i64 = BuiltinType(entity: .i64, type: ty.Integer(entity: .i64, width: 64, isSigned: true))
-    static let u64 = BuiltinType(entity: .u64, type: ty.Integer(entity: .u64, width: 64, isSigned: false))
+    static let i8  = BuiltinType(entity: .i8,  type: ty.Integer(width: 8,  isSigned: true))
+    static let u8  = BuiltinType(entity: .u8,  type: ty.Integer(width: 8,  isSigned: false))
+    static let i16 = BuiltinType(entity: .i16, type: ty.Integer(width: 16, isSigned: true))
+    static let u16 = BuiltinType(entity: .u16, type: ty.Integer(width: 16, isSigned: false))
+    static let i32 = BuiltinType(entity: .i32, type: ty.Integer(width: 32, isSigned: true))
+    static let u32 = BuiltinType(entity: .u32, type: ty.Integer(width: 32, isSigned: false))
+    static let i64 = BuiltinType(entity: .i64, type: ty.Integer(width: 64, isSigned: true))
+    static let u64 = BuiltinType(entity: .u64, type: ty.Integer(width: 64, isSigned: false))
 
     static let untypedInteger = BuiltinType(entity: .anonymous, type: ty.UntypedInteger())
     static let untypedFloat   = BuiltinType(entity: .anonymous, type: ty.UntypedFloatingPoint())
@@ -139,7 +138,7 @@ class BuiltinFunction {
     /// - Note: OutTypes must be metatypes and will be made instance instanceTypes
     static func make(_ name: String, in inTypes: [Type], out outTypes: [Type], isVariadic: Bool = false, gen: @escaping Generate, onCallCheck: CallCheck? = nil) -> BuiltinFunction {
         let returnType = ty.Tuple.make(outTypes.map(ty.Metatype.init))
-        let type = ty.Function(entity: nil, node: nil, labels: nil, params: inTypes, returnType: returnType, flags: .none)
+        let type = ty.Function(node: nil, labels: nil, params: inTypes, returnType: returnType, flags: .none)
 
         let ident = Ident(start: noPos, name: name, entity: nil, type: nil, conversion: nil, constant: nil)
         let entity = Entity(ident: ident, type: type)

--- a/Sources/Core/Descriptions/Type+Description.swift
+++ b/Sources/Core/Descriptions/Type+Description.swift
@@ -7,45 +7,30 @@ extension ty.Void: CustomStringConvertible {
 
 extension ty.Boolean {
     var description: String {
-        if let name = entity?.name {
-            return name
-        }
         return "bool"
     }
 }
 
 extension ty.Integer {
     var description: String {
-        if let name = entity?.name {
-            return name
-        }
         return "\(isSigned ? "i" : "u")\(width!)"
     }
 }
 
 extension ty.FloatingPoint {
     var description: String {
-        if let name = entity?.name {
-            return name
-        }
         return "f\(width!)"
     }
 }
 
 extension ty.KaiString {
     var description: String {
-        if let name = entity?.name {
-            return name
-        }
         return "string"
     }
 }
 
 extension ty.Pointer {
     var description: String {
-        if let name = entity?.name {
-            return name
-        }
         return "*" + pointeeType.description
     }
 }
@@ -58,18 +43,12 @@ extension ty.Anyy {
 
 extension ty.Struct {
     var description: String {
-        if let name = entity?.name {
-            return name
-        }
         return "struct{" + fields.orderedValues.map({ $0.ident.name + ": " + $0.type.description }).joined(separator: ", ") + "}"
     }
 }
 
 extension ty.Union {
     var description: String {
-        if let name = entity?.name {
-            return name
-        }
 
         return "union{" + cases.orderedValues.map({ $0.ident.name + ": " + $0.type.description }).joined(separator: ", ") + "}"
     }
@@ -77,49 +56,25 @@ extension ty.Union {
 
 extension ty.Variant {
     var description: String {
-        if let name = entity?.name {
-            return name
-        }
-
         return "variant{" + cases.orderedValues.map({ $0.ident.name + ": " + $0.type.description }).joined(separator: ", ") + "}"
     }
 }
 
 extension ty.Enum {
     var description: String {
-        if let name = entity?.name {
-            return name
-        }
         return "enum{" + cases.orderedValues.map({ $0.ident.name + ($0.value.map({ " = " + String(describing: $0) }) ?? "") }).joined(separator: ", ") + "}"
     }
 }
 
 extension ty.Array {
     var description: String {
-        var str = ""
-        if let name = entity?.name {
-            str += name + " aka "
-        }
-
-        str += "["
-
-        if length != nil {
-            str += "\(length!)"
-        }
-
-        str += "]" + elementType.description
-        return str
+        return "[" + length!.description + "]" + elementType.description
     }
 }
 
 extension ty.Slice {
     var description: String {
-        var str = ""
-        if let name = entity?.name {
-            str += name + " aka "
-        }
-        str += "[]" + elementType.description
-        return str
+        return "[]" + elementType.description
     }
 }
 
@@ -131,12 +86,13 @@ extension ty.Vector {
 
 extension ty.Function {
     var description: String {
-        var str = ""
-        if let name = entity?.name {
-            str += name + " aka "
-        }
-        str += "(" + params.map({ $0.description }).joined(separator: ", ") + ") -> " + returnType.description
-        return str
+        return "(" + params.map({ $0.description }).joined(separator: ", ") + ") -> " + returnType.description
+    }
+}
+
+extension ty.Named {
+    var description: String {
+        return entity.name
     }
 }
 

--- a/Sources/Core/Parser.swift
+++ b/Sources/Core/Parser.swift
@@ -50,7 +50,7 @@ extension Parser {
         } else {
             reportExpected("string literal", at: pos)
         }
-        return BasicLit(start: start, token: .string, text: val, type: nil, constant: unquote(val))
+        return BasicLit(start: start, token: .string, text: val, type: nil, constant: unquote(val), conversion: nil)
     }
 
     mutating func parseIdent() -> Ident {
@@ -280,11 +280,11 @@ extension Parser {
         case .ident:
             return parseIdent()
         case .string:
-            let val = BasicLit(start: pos, token: tok, text: lit, type: nil, constant: unquote(lit))
+            let val = BasicLit(start: pos, token: tok, text: lit, type: nil, constant: unquote(lit), conversion: nil)
             next()
             return val
         case .int, .float:
-            let val = BasicLit(start: pos, token: tok, text: lit, type: nil, constant: nil)
+            let val = BasicLit(start: pos, token: tok, text: lit, type: nil, constant: nil, conversion: nil)
             next()
             return val
         case .fn:

--- a/Sources/Core/generated/Copy.generated.swift
+++ b/Sources/Core/generated/Copy.generated.swift
@@ -80,7 +80,8 @@ func copy(_ node: BasicLit) -> BasicLit {
         token: node.token,
         text: node.text,
         type: node.type,
-        constant: node.constant
+        constant: node.constant,
+        conversion: node.conversion
     )
 }
 


### PR DESCRIPTION
This complicates things but is needed to support indirectly recursive types.
@BrettRToomey I would be interested to see what you think, I don't like having to do `baseType(type)` all over the place for when we want to switch on the type. I can't think of anything much better though.