### PR TITLE
Declaration refactor

### DIFF
--- a/code/examples/ack.kai
+++ b/code/examples/ack.kai
@@ -1,0 +1,13 @@
+
+#import kai("posix")
+
+ack :: fn(m, n: u32) -> u32 {
+    if m == 0 return n + 1
+    if n == 0 return ack(m - 1, 1)
+    return ack(m - 1, ack(m, n - 1))
+}
+
+main :: fn() -> void {
+    x := ack(3, 1)
+    posix.printf("%u\n".raw, x)
+}


### PR DESCRIPTION
This PR aims to separate the checking of variable and value declarations, and remove some finicky poorly defined behavior around calls to multiple return functions appearing in value list.